### PR TITLE
Added offset and better spritesheet importing

### DIFF
--- a/addons/ch.fischspiele.tilesethelper/tilesethelper.gd
+++ b/addons/ch.fischspiele.tilesethelper/tilesethelper.gd
@@ -15,13 +15,11 @@ var checkOccluder = false
 var mainGuiPath = "VBoxContainer/PanelContainer/VBoxContainer/"
 var imagesPath
 var fileDialog = null
-var lastPosition
-var gap = 10
 
 func _enter_tree():
 	dock = preload("res://addons/ch.fischspiele.tilesethelper/tilesethelper_dock.tscn").instance()
 	#image
-	dock.get_node(mainGuiPath+"HBoxImage/VBoxImage/sizeBox/size").connect("text_changed",self,"updateTilesize")
+	dock.get_node(mainGuiPath+"HBoxImage/VBoxImage/sizeBox/size").connect("text_changed",self,"tilesize")
 	dock.get_node(mainGuiPath+"HBoxImage/VBoxImage/sizeBox/size").set_text(str(tileSize))
 	dock.get_node(mainGuiPath+"HBoxImage/CheckBox").connect("toggled",self,"setImageCheck")
 	#frames
@@ -29,6 +27,11 @@ func _enter_tree():
 	dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").set_text("0")
 	dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").set_editable(false)
 	dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").set_editable(false)
+	#Offset
+	dock.get_node(mainGuiPath+"HBoxFrameOffset/XOffset").set_text("0")
+	dock.get_node(mainGuiPath+"HBoxFrameOffset/YOffset").set_text("0")
+	dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").set_editable(true)
+	dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").set_editable(true)
 	#dialog
 	dock.get_node(mainGuiPath+"HBoxImage/ImageContainer/btnImage").connect("pressed",self,"show_dialog")
 	#collision
@@ -47,87 +50,6 @@ func _enter_tree():
 	dock.get_node(mainGuiPath+"create_tiles").connect("pressed",self,"create_tiles")
 	add_control_to_dock( DOCK_SLOT_RIGHT_BL, dock )
 
-
-func create_tiles():
-	if checkImage:
-		addImageNodes()
-	else:
-		if checkCollision:
-			collisionPolygon()
-		if checkNavigation:
-			navigation()
-		if checkOccluder:
-			occluder()
-
-func addImageNodes():
-	print("creating ",imagesPath.size()," sprites from selection")
-	var _root =  get_tree().get_edited_scene_root()
-	if _root != null:
-		lastPosition = getStartingPosition()
-		if dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").is_editable():
-			#Image cutting
-			for _imagePath in imagesPath:
-				var _newTexture  = ImageTexture.new()
-				_newTexture.load(_imagePath)
-				_newTexture.set_flags(0)
-				var _startFrame = int(dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").get_text())
-				var _endFrame = int(dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").get_text())
-				for _frame in range(_startFrame,_endFrame):
-					var column = int(_frame)%int(hFrames)
-					var row = int(_frame/hFrames)
-					var newPosition = Vector2(column*(tileSize+gap),lastPosition.y+row*(tileSize+gap))
-					var _imageName = getFileName(_imagePath)+str(_frame)
-					var _newSpriteNode
-					if !_root.has_node(_imageName):
-						_newSpriteNode = Sprite.new()
-						_newSpriteNode.set_texture(_newTexture)
-						_newSpriteNode.set_vframes(vFrames)
-						_newSpriteNode.set_hframes(hFrames)
-						_newSpriteNode.set_frame(_frame)
-						_root.add_child(_newSpriteNode)
-						_newSpriteNode.set_pos(newPosition)
-						_newSpriteNode.set_owner(_root)
-						_newSpriteNode.set_name(_imageName)
-					else:
-						_newSpriteNode = _root.get_node(_imageName)
-						_newSpriteNode.set_texture(_newTexture)
-						_newSpriteNode.set_vframes(vFrames)
-						_newSpriteNode.set_hframes(hFrames)
-						_newSpriteNode.set_frame(_frame)
-					if checkCollision:
-						setCollisionPolygon(_newSpriteNode)
-					if checkNavigation:
-						setNavigation(_newSpriteNode)
-					if checkOccluder:
-						setOccluder(_newSpriteNode)
-		else:
-			for _imagePath in imagesPath:
-				var _newTexture  = ImageTexture.new()
-				_newTexture.load(_imagePath)
-				_newTexture.set_flags(0)
-				tileSize = _newTexture.get_width()
-				var _imageName = getFileName(_imagePath)
-				var _newSpriteNode
-				if !_root.has_node(_imageName):
-					_newSpriteNode = Sprite.new()
-					_newSpriteNode.set_texture(_newTexture)
-					_root.add_child(_newSpriteNode)
-					_newSpriteNode.set_pos(lastPosition)
-					_newSpriteNode.set_owner(_root)
-					_newSpriteNode.set_name(_imageName)
-				else:
-					_newSpriteNode = _root.get_node(_imageName)
-					_newSpriteNode.set_texture(_newTexture)
-				if checkCollision:
-					setCollisionPolygon(_newSpriteNode)
-				if checkNavigation:
-					setNavigation(_newSpriteNode)
-				if checkOccluder:
-					setOccluder(_newSpriteNode)
-				lastPosition = Vector2(lastPosition.x+tileSize+gap,lastPosition.y)
-	else:
-		printerr("ERROR: no root node found")
-
 func collisionPolygon():
 	print("add/remove collisionPolygon")
 	for seletedNode in get_selection().get_selected_nodes():
@@ -140,12 +62,10 @@ func setCollisionPolygon(seletedNode):
 		var _newCollisionPolygonNode = CollisionPolygon2D.new()
 		_newCollisionPolygonNode.set_polygon(getVector2ArrayFromSprite(seletedNode))
 		_newCollisionPolygonNode.set_name("CollisionPolygon2D")
-		_newCollisionPolygonNode.set_meta("_edit_lock_",true)
 		_newStaticBodyNode.add_child(_newCollisionPolygonNode)
-		_newStaticBodyNode.set_meta("_edit_lock_",true)
 		_newCollisionPolygonNode.set_owner(_owner)
 	else:
-		printerr("ERROR: root node selected")
+		print("Error: root node selected")
 
 func occluder():
 	print("add/remove occluder")
@@ -161,13 +81,12 @@ func setOccluder(seletedNode):
 			var _newLightOccluderNode = LightOccluder2D.new()
 			_newLightOccluderNode.set_occluder_polygon(getOccPolygon2D(seletedNode))
 			_newLightOccluderNode.set_name("LightOccluder2D")
-			_newLightOccluderNode.set_meta("_edit_lock_",true)
 			seletedNode.add_child(_newLightOccluderNode)
 			_newLightOccluderNode.set_owner(seletedNode.get_parent())
 		else:
-			printerr("ERROR: no sprite selected")
+			print("Error: no sprite selected")
 	else:
-		printerr("ERROR: root node selected")
+		print("Error: root node selected")
 
 func navigation():
 	print("add/remove navigation")
@@ -182,13 +101,12 @@ func setNavigation(seletedNode):
 			var _newNavigationPolygonNode = NavigationPolygonInstance.new()
 			_newNavigationPolygonNode.set_navigation_polygon(getNavPolygon(seletedNode))
 			_newNavigationPolygonNode.set_name("NavigationPolygonInstance")
-			_newNavigationPolygonNode.set_meta("_edit_lock_",true)
 			seletedNode.add_child(_newNavigationPolygonNode)
 			_newNavigationPolygonNode.set_owner(seletedNode.get_parent())
 		else:
-			printerr("ERROR: no sprite selected")
+			print("Error: no sprite selected")
 	else:
-		printerr("ERROR: root node selected")
+		print("Error: root node selected")
 
 func getVector2ArrayFromSprite(selectedNode):
 	var _Array = []
@@ -198,6 +116,9 @@ func getVector2ArrayFromSprite(selectedNode):
 	_Vector2Array.append(Vector2(tileSize/2,tileSize/2))
 	_Vector2Array.append(Vector2(-tileSize/2,tileSize/2))
 	return _Vector2Array
+
+func getVector2ArrayFromCollision(selectedNode):
+	return selectedNode.get_node("StaticBody2D/CollisionPolygon2D").get_polygon()
 
 func getNavPolygon(selectedNode):
 	var _navPoly = NavigationPolygon.new()
@@ -210,7 +131,7 @@ func getNavPolygon(selectedNode):
 	_navPoly.add_polygon(IntArray([0, 1, 2, 3]))
 	_navPoly.set_vertices(_polyArray)
 	return _navPoly
-	
+
 func getOccPolygon2D(selectedNode):
 	var _occPoly = OccluderPolygon2D.new()
 	var _polyArray = null
@@ -220,6 +141,20 @@ func getOccPolygon2D(selectedNode):
 		_polyArray = getVector2ArrayFromSprite(selectedNode)
 	_occPoly.set_polygon(_polyArray)
 	return _occPoly
+
+func tilesize(newTileSize):
+	tileSize = int(newTileSize)
+	if tileSize < oneImageSelectedSize.x && tileSize > 0:
+		var _newTexture  = ImageTexture.new()
+		_newTexture.load("res://addons/ch.fischspiele.tilesethelper/gui_image_tileset.png")
+		hFrames = oneImageSelectedSize.x/tileSize
+		vFrames = oneImageSelectedSize.y/tileSize
+		dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").set_text("0")
+		dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").set_text(str(hFrames*vFrames))
+		dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").set_editable(true)
+		dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").set_editable(true)
+	else:
+		disableFramesGui()
 
 func setStaticBody(selectedNode,owner):
 	if selectedNode.has_node("StaticBody2D"):
@@ -234,23 +169,21 @@ func setStaticBody(selectedNode,owner):
 	_newStaticBodyNode.set_owner(owner)
 	return _newStaticBodyNode
 
-###
-### - - Events
-###
-func updateTilesize(newTileSize):
-	tileSize = int(newTileSize)
-	gap = int(tileSize/2)
-	if tileSize < oneImageSelectedSize.x && tileSize > 0 && isImageSizePowerOf2(oneImageSelectedSize):
-		var _newTexture  = ImageTexture.new()
-		_newTexture.load("res://addons/ch.fischspiele.tilesethelper/gui_image_tileset.png")
-		hFrames = oneImageSelectedSize.x/tileSize
-		vFrames = oneImageSelectedSize.y/tileSize
-		dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").set_text("0")
-		dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").set_text(str(hFrames*vFrames))
-		dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").set_editable(true)
-		dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").set_editable(true)
-	else:
-		disableFramesGui()
+func show_dialog():
+	if fileDialog == null:
+		fileDialog = FileDialog.new()
+		get_parent().add_child(fileDialog)
+
+	fileDialog.set_mode(FileDialog.MODE_OPEN_FILES)
+	fileDialog.set_current_path("res://")
+	fileDialog.set_access(FileDialog.ACCESS_RESOURCES)
+	fileDialog.clear_filters()
+	fileDialog.add_filter("*.png ; PNG Images");
+	fileDialog.set_custom_minimum_size(Vector2(500,500))
+	fileDialog.popup_centered()
+	fileDialog.show()
+	if not fileDialog.is_connected("files_selected",self,"on_files_selected"):
+		fileDialog.connect("files_selected",self,"on_files_selected")
 
 func on_files_selected(imagePathArray):
 	imagesPath = imagePathArray
@@ -265,8 +198,6 @@ func on_files_selected(imagePathArray):
 		_newTexture.load(imagePathArray[0])
 		_newSize = _newTexture.get_width()
 		oneImageSelectedSize = Vector2(_newTexture.get_width(),_newTexture.get_height())
-		if isImageSizePowerOf2(oneImageSelectedSize):
-			dock.get_node(mainGuiPath+"HBoxImageFrame").show()
 		if _newTexture.get_width() > 64 || _newTexture.get_height() > 64:
 			_newTexture.set_size_override(Vector2(64,64))
 		_newName = getFileName(imagePathArray[0])
@@ -276,33 +207,106 @@ func on_files_selected(imagePathArray):
 		_newSize = ""
 		_newTexture.load("res://addons/ch.fischspiele.tilesethelper/gui_image_multiple.png")
 		_newName = "..."
-	
+
 	dock.get_node(mainGuiPath+"HBoxImage/ImageContainer/TextureFrame").set_texture(_newTexture)
 	dock.get_node(mainGuiPath+"HBoxImage/VBoxImage/sizeBox/size").set_text(str(_newSize))
-	dock.get_node(mainGuiPath+"HBoxImage/VBoxImage/lblName").set_text(_newName)
+	dock.get_node(mainGuiPath+"HBoxImage/VBoxImage/name/lblName").set_text(_newName)
+
+func create_tiles():
+	if checkImage:
+		addImageNodes()
+	else:
+		if checkCollision:
+			collisionPolygon()
+		if checkNavigation:
+			navigation()
+		if checkOccluder:
+			occluder()
+
+func addImageNodes():
+	print("creating ",imagesPath.size()," sprites from selection")
+	var _root =  get_tree().get_edited_scene_root()
+	if dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").is_editable():
+		for _imagePath in imagesPath:
+			var _newTexture  = ImageTexture.new()
+			_newTexture.load(_imagePath)
+			_newTexture.set_flags(0)
+			var _startFrame = int(dock.get_node(mainGuiPath+"HBoxImageFrame/frame1").get_text())
+			var _endFrame = int(dock.get_node(mainGuiPath+"HBoxImageFrame/frame2").get_text())
+			var offsetX = int(dock.get_node(mainGuiPath+"HBoxFrameOffset/XOffset").get_text())
+			var offsetY = int(dock.get_node(mainGuiPath+"HBoxFrameOffset/YOffset").get_text())
+			var tilesWide = int((_newTexture.get_size().x + offsetX) / (int(tileSize) + offsetX))
+			var tilesTall = int((_newTexture.get_size().y + offsetY) / (int(tileSize) + offsetY))
+			for _frame in range(_startFrame,_endFrame):
+				var _imageName = getFileName(_imagePath)+str(_frame)
+				var _newSpriteNode
+				if !_root.has_node(_imageName):
+					_newSpriteNode = Sprite.new()
+					_newSpriteNode.set_texture(_newTexture)
+					_newSpriteNode.set_vframes(vFrames)
+					_newSpriteNode.set_hframes(hFrames)
+
+					if (int(tileSize) < _newTexture.get_size().x):
+						_newSpriteNode.set_region(true)
+
+						var tmpX = offsetX
+						if _frame % tilesWide == 0:
+							tmpX = 0
+						var tmpY = offsetY
+						if _frame / tilesWide < 1:
+							tmpY = 0
+						var position = Vector2 ((tmpX + int(tileSize)) * (int(_frame) % tilesWide) , (tmpY + int(tileSize)) * int((int(_frame) / tilesWide) - .5))
+						_newSpriteNode.set_region_rect( Rect2( position, Vector2(int(tileSize), int(tileSize))) )
+						_newSpriteNode.set_pos(position)
+					else:
+						_newSpriteNode.set_pos(Vector2(0,0))
+					_newSpriteNode.set_frame(_frame)
+					_root.add_child(_newSpriteNode)
+					_newSpriteNode.set_owner(_root)
+					_newSpriteNode.set_name(_imageName)
+				else:
+					_newSpriteNode = _root.get_node(_imageName)
+					_newSpriteNode.set_texture(_newTexture)
+					_newSpriteNode.set_vframes(vFrames)
+					_newSpriteNode.set_hframes(hFrames)
+					_newSpriteNode.set_frame(_frame)
+				if checkCollision:
+					setCollisionPolygon(_newSpriteNode)
+				if checkNavigation:
+					setNavigation(_newSpriteNode)
+				if checkOccluder:
+					setOccluder(_newSpriteNode)
+	else:
+		for _imagePath in imagesPath:
+			var _newTexture  = ImageTexture.new()
+			_newTexture.load(_imagePath)
+			_newTexture.set_flags(0)
+			tileSize = _newTexture.get_width()
+			var _imageName = getFileName(_imagePath)
+			var _newSpriteNode
+			if !_root.has_node(_imageName):
+				_newSpriteNode = Sprite.new()
+				_newSpriteNode.set_texture(_newTexture)
+				_root.add_child(_newSpriteNode)
+				_newSpriteNode.set_pos(Vector2(0,0))
+				_newSpriteNode.set_owner(_root)
+				_newSpriteNode.set_name(_imageName)
+			else:
+				_newSpriteNode = _root.get_node(_imageName)
+				_newSpriteNode.set_texture(_newTexture)
+			if checkCollision:
+				setCollisionPolygon(_newSpriteNode)
+			if checkNavigation:
+				setNavigation(_newSpriteNode)
+			if checkOccluder:
+				setOccluder(_newSpriteNode)
 
 ###
 ###  - - GUI Helper functions
 ###
-func show_dialog():
-	if fileDialog == null:
-		fileDialog = FileDialog.new()
-		get_parent().add_child(fileDialog)
-	
-	fileDialog.set_mode(FileDialog.MODE_OPEN_FILES)
-	fileDialog.set_current_path("res://")
-	fileDialog.set_access(FileDialog.ACCESS_RESOURCES)
-	fileDialog.clear_filters()
-	fileDialog.add_filter("*.png ; PNG Images");
-	fileDialog.set_custom_minimum_size(Vector2(500,500))
-	fileDialog.popup_centered()
-	fileDialog.show()
-	if not fileDialog.is_connected("files_selected",self,"on_files_selected"):
-		fileDialog.connect("files_selected",self,"on_files_selected")
-
 func setCollisionPolygonCheck(newValue):
 	checkCollision = newValue
-	
+
 func setImageCheck(newValue):
 	checkImage = newValue
 
@@ -330,37 +334,9 @@ func _exit_tree():
 ###
 ### - - Helper functions
 ###
-func getVector2ArrayFromCollision(selectedNode):
-	return selectedNode.get_node("StaticBody2D/CollisionPolygon2D").get_polygon() 
-
 func getFileName(_path):
 	var _fileName = _path.substr(_path.find_last("/")+1, _path.length() - _path.find_last("/")-1)
 	var _dotPos = _fileName.find_last(".")
 	if _dotPos != -1:
 		_fileName = _fileName.substr(0,_dotPos)
 	return _fileName
-
-func isImageSizePowerOf2(_imageSize):
-	var _status = 0
-	var _power2List = [2,4,8,16,32,64,128,256,512,1024,2048,4096,8192]
-	for _power2Number in _power2List:
-		if _imageSize.x == _power2Number:
-			_status += 1
-		if _imageSize.y == _power2Number:
-			_status += 1
-	if _status != 2:
-		dock.get_node(mainGuiPath+"HBoxImageFrame").hide()
-		print("WARN: selected image is not power of 2, frames disabled")
-	return _status == 2
-
-func getStartingPosition():
-	var _root =  get_tree().get_edited_scene_root()
-	if _root.get_children().size() == 0:
-		return Vector2(0,0)
-	else:
-		var yPos = 0
-		for child in _root.get_children():
-			if child.get_pos().y > yPos:
-				 yPos = child.get_pos().y
-		return Vector2(0,yPos+(tileSize+gap))
-			

--- a/addons/ch.fischspiele.tilesethelper/tilesethelper_dock.tscn
+++ b/addons/ch.fischspiele.tilesethelper/tilesethelper_dock.tscn
@@ -11,10 +11,10 @@ focus/ignore_mouse = false
 focus/stop_mouse = false
 size_flags/horizontal = 0
 size_flags/vertical = 2
-margin/left = 0.0
-margin/top = 0.0
-margin/right = 232.0
-margin/bottom = 333.0
+margin/left = 3.0
+margin/top = -2.0
+margin/right = 235.0
+margin/bottom = 372.0
 use_top_left = false
 __meta__ = { "__editor_plugin_screen__":"2D" }
 
@@ -26,9 +26,9 @@ focus/stop_mouse = false
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 0.0
+margin/top = 1.0
 margin/right = 232.0
-margin/bottom = 333.0
+margin/bottom = 372.0
 alignment = 1
 
 [node name="PanelContainer" type="PanelContainer" parent="VBoxContainer"]
@@ -40,7 +40,7 @@ size_flags/vertical = 2
 margin/left = 0.0
 margin/top = 0.0
 margin/right = 232.0
-margin/bottom = 333.0
+margin/bottom = 371.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/PanelContainer"]
 
@@ -51,12 +51,11 @@ size_flags/vertical = 0
 margin/left = 7.0
 margin/top = 7.0
 margin/right = 225.0
-margin/bottom = 326.0
+margin/bottom = 364.0
 alignment = 0
 
 [node name="HBoxImage" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 
-editor/display_folded = true
 focus/ignore_mouse = false
 focus/stop_mouse = false
 size_flags/horizontal = 2
@@ -85,7 +84,6 @@ align = 0
 
 [node name="ImageContainer" type="CenterContainer" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxImage"]
 
-editor/display_folded = true
 rect/min_size = Vector2( 64, 64 )
 focus/ignore_mouse = false
 focus/stop_mouse = true
@@ -155,7 +153,19 @@ percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
 
-[node name="lblName" type="LineEdit" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxImage/VBoxImage"]
+[node name="name" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxImage/VBoxImage"]
+
+focus/ignore_mouse = false
+focus/stop_mouse = false
+size_flags/horizontal = 2
+size_flags/vertical = 2
+margin/left = 0.0
+margin/top = 18.0
+margin/right = 120.0
+margin/bottom = 42.0
+alignment = 0
+
+[node name="lblName" type="LineEdit" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxImage/VBoxImage/name"]
 
 rect/min_size = Vector2( 120, 0 )
 focus/ignore_mouse = false
@@ -163,12 +173,11 @@ focus/stop_mouse = true
 size_flags/horizontal = 0
 size_flags/vertical = 1
 margin/left = 0.0
-margin/top = 18.0
+margin/top = 0.0
 margin/right = 120.0
-margin/bottom = 42.0
-placeholder/text = "imageName"
+margin/bottom = 24.0
 placeholder/alpha = 0.6
-editable = false
+align = 1
 focus_mode = 2
 caret/caret_blink = false
 caret/caret_blink_speed = 0.65
@@ -185,18 +194,18 @@ margin/right = 120.0
 margin/bottom = 70.0
 alignment = 0
 
-[node name="Label" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxImage/VBoxImage/sizeBox"]
+[node name="lblSize" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxImage/VBoxImage/sizeBox"]
 
-rect/min_size = Vector2( 58, 0 )
 focus/ignore_mouse = true
 focus/stop_mouse = true
-size_flags/horizontal = 2
+size_flags/horizontal = 3
 size_flags/vertical = 0
 margin/left = 0.0
 margin/top = 5.0
 margin/right = 58.0
 margin/bottom = 19.0
-text = "Tilesize:"
+text = "Size:"
+align = 2
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
@@ -214,15 +223,12 @@ margin/bottom = 24.0
 text = "0"
 placeholder/alpha = 0.6
 align = 1
-max_length = 4
 focus_mode = 2
 caret/caret_blink = false
 caret/caret_blink_speed = 0.65
 
 [node name="HBoxImageFrame" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 
-editor/display_folded = true
-visibility/visible = false
 rect/min_size = Vector2( 0, 24 )
 focus/ignore_mouse = false
 focus/stop_mouse = false
@@ -264,7 +270,7 @@ margin/bottom = 24.0
 text = "10"
 placeholder/alpha = 0.6
 align = 1
-max_length = 3
+max_length = 9
 editable = false
 focus_mode = 2
 caret/caret_blink = false
@@ -301,8 +307,92 @@ margin/bottom = 24.0
 text = "20"
 placeholder/alpha = 0.6
 align = 1
-max_length = 3
+max_length = 9
 editable = false
+focus_mode = 2
+caret/caret_blink = false
+caret/caret_blink_speed = 0.65
+
+[node name="HBoxFrameOffset" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer"]
+
+rect/min_size = Vector2( 0, 24 )
+focus/ignore_mouse = false
+focus/stop_mouse = false
+size_flags/horizontal = 2
+size_flags/vertical = 2
+margin/left = 0.0
+margin/top = 102.0
+margin/right = 218.0
+margin/bottom = 126.0
+alignment = 1
+
+[node name="lblFrom" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxFrameOffset"]
+
+rect/min_size = Vector2( 70, 0 )
+focus/ignore_mouse = true
+focus/stop_mouse = true
+size_flags/horizontal = 0
+size_flags/vertical = 0
+margin/left = 0.0
+margin/top = 5.0
+margin/right = 70.0
+margin/bottom = 19.0
+text = "Offset X:"
+align = 2
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+
+[node name="XOffset" type="LineEdit" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxFrameOffset"]
+
+focus/ignore_mouse = false
+focus/stop_mouse = true
+size_flags/horizontal = 2
+size_flags/vertical = 2
+margin/left = 74.0
+margin/top = 0.0
+margin/right = 132.0
+margin/bottom = 24.0
+text = "0"
+placeholder/alpha = 0.6
+align = 1
+max_length = 3
+focus_mode = 2
+caret/caret_blink = false
+caret/caret_blink_speed = 0.65
+
+[node name="lblTo" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxFrameOffset"]
+
+rect/min_size = Vector2( 20, 0 )
+focus/ignore_mouse = true
+focus/stop_mouse = true
+size_flags/horizontal = 2
+size_flags/vertical = 0
+margin/left = 136.0
+margin/top = 5.0
+margin/right = 156.0
+margin/bottom = 19.0
+text = "Y:"
+align = 1
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+
+[node name="YOffset" type="LineEdit" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxFrameOffset"]
+
+focus/ignore_mouse = false
+focus/stop_mouse = true
+size_flags/horizontal = 0
+size_flags/vertical = 0
+size_flags/stretch_ratio = 0.0
+margin/left = 160.0
+margin/top = 0.0
+margin/right = 218.0
+margin/bottom = 24.0
+text = "0"
+placeholder/alpha = 0.6
+align = 1
+max_length = 3
 focus_mode = 2
 caret/caret_blink = false
 caret/caret_blink_speed = 0.65
@@ -315,22 +405,21 @@ focus/stop_mouse = true
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 74.0
+margin/top = 130.0
 margin/right = 218.0
-margin/bottom = 80.0
+margin/bottom = 136.0
 
 [node name="HBoxCollision" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 
-editor/display_folded = true
 rect/min_size = Vector2( 0, 24 )
 focus/ignore_mouse = false
 focus/stop_mouse = false
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 84.0
+margin/top = 140.0
 margin/right = 218.0
-margin/bottom = 114.0
+margin/bottom = 170.0
 alignment = 1
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxCollision"]
@@ -375,9 +464,9 @@ focus/stop_mouse = true
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 118.0
+margin/top = 174.0
 margin/right = 218.0
-margin/bottom = 124.0
+margin/bottom = 180.0
 
 [node name="HBoxNavigation" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 
@@ -388,9 +477,9 @@ focus/stop_mouse = false
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 128.0
+margin/top = 184.0
 margin/right = 218.0
-margin/bottom = 158.0
+margin/bottom = 214.0
 alignment = 1
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxNavigation"]
@@ -435,9 +524,9 @@ focus/stop_mouse = true
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 162.0
+margin/top = 218.0
 margin/right = 218.0
-margin/bottom = 168.0
+margin/bottom = 224.0
 
 [node name="HBoxOccluder" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 
@@ -448,9 +537,9 @@ focus/stop_mouse = false
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 172.0
+margin/top = 228.0
 margin/right = 218.0
-margin/bottom = 202.0
+margin/bottom = 258.0
 alignment = 1
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxOccluder"]
@@ -495,9 +584,9 @@ focus/stop_mouse = true
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 206.0
+margin/top = 262.0
 margin/right = 218.0
-margin/bottom = 212.0
+margin/bottom = 268.0
 
 [node name="HBoxSettings" type="HBoxContainer" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 
@@ -508,9 +597,9 @@ focus/stop_mouse = false
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 216.0
+margin/top = 272.0
 margin/right = 218.0
-margin/bottom = 247.0
+margin/bottom = 303.0
 alignment = 1
 
 [node name="CheckGetPolyColli" type="CheckButton" parent="VBoxContainer/PanelContainer/VBoxContainer/HBoxSettings"]
@@ -553,9 +642,9 @@ focus/stop_mouse = true
 size_flags/horizontal = 2
 size_flags/vertical = 2
 margin/left = 0.0
-margin/top = 251.0
+margin/top = 307.0
 margin/right = 218.0
-margin/bottom = 257.0
+margin/bottom = 313.0
 
 [node name="create_tiles" type="Button" parent="VBoxContainer/PanelContainer/VBoxContainer"]
 
@@ -565,29 +654,12 @@ focus/stop_mouse = true
 size_flags/horizontal = 0
 size_flags/vertical = 0
 margin/left = 59.0
-margin/top = 261.0
+margin/top = 317.0
 margin/right = 159.0
-margin/bottom = 301.0
+margin/bottom = 357.0
 toggle_mode = false
 click_on_press = true
 enabled_focus_mode = 2
 shortcut = null
 text = "Create Tile(s)"
 flat = false
-
-[node name="errormessage" type="Label" parent="VBoxContainer/PanelContainer/VBoxContainer"]
-
-focus/ignore_mouse = true
-focus/stop_mouse = true
-size_flags/horizontal = 2
-size_flags/vertical = 0
-margin/left = 0.0
-margin/top = 305.0
-margin/right = 218.0
-margin/bottom = 319.0
-align = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
-
-


### PR DESCRIPTION
Wrote update to improve importing from a sprite sheet and when importing you can specify an offset if each image has a buffer of x or y pixels away from each other. This will also space each item out to look identical to the sprite sheet. 

Example image: [Image Link](https://gyazo.com/c39fb65573769fb9b1cb6e96acf1794f)