### PR TITLE
Update tilesethelper.gd

### DIFF
--- a/addons/ch.fischspiele.tilesethelper/tilesethelper.gd
+++ b/addons/ch.fischspiele.tilesethelper/tilesethelper.gd
@@ -329,7 +329,7 @@ func disableFramesGui():
 
 func _exit_tree():
 	remove_control_from_docks(dock)
-	dock.free()
+	dock.queue_free()
 
 ###
 ### - - Helper functions


### PR DESCRIPTION
Changed _exit_tree() so that the dock frees properly when the plugin is deactivated. The dock didn't go away when the plugin was deactivated, it just became unresponsive and new instances were added to additional tabs.

EDIT: Sorry, this seems to have fixed it on the project I was originally testing on, but not on any others I try to copy my version of the script to. I'll reupload when I've got it working properly.